### PR TITLE
Add consolidated Xfit metrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,10 @@ pages are rendered with Jinja2 templates under `templates/`.
 ## MikroTik Integration
 - MikroTik devices are accessed using the `librouteros` library.
 - Configure `MIKROTIK_USER` and `MIKROTIK_PASSWORD` in the environment.
-- The `/metrics` endpoint exposes channel metrics for Prometheus.
-- The `/icmp_stats` endpoint returns ICMP loss and response time as JSON for Grafana.
+- The `/metrics` endpoint exposes channel status and ICMP statistics for
+  hosts in the `Xfit` group. Channel information is taken from hosts named
+  `<name>.Gr3`.
+- The `/icmp_stats` endpoint returns the same metrics as JSON for Grafana.
 
 ## Commit Messages
 Describe the intent of the change briefly, e.g. "Add error handling to

--- a/app/zabbix_api.py
+++ b/app/zabbix_api.py
@@ -179,3 +179,19 @@ def get_icmp_metrics(host_id, auth):
         if name == "ICMP response time avg 1m":
             metrics["resp_1m"] = float(value)
     return metrics
+
+
+def get_host_ip(host_name: str, auth: str) -> str:
+    """Return the primary interface IP for a host by name."""
+
+    params = {
+        "output": ["hostid", "name"],
+        "selectInterfaces": ["ip"],
+        "filter": {"name": [host_name]},
+        "limit": 1,
+    }
+    hosts = zabbix_request("host.get", params, auth)
+    if not hosts:
+        print(f"[ZBX] Host '{host_name}' not found")
+        return ""
+    return hosts[0].get("interfaces", [{}])[0].get("ip", "")

--- a/templates/channel_status.html
+++ b/templates/channel_status.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-    <h1>Список хостов из групп Xfit и Gr3</h1>
+    <h1>Список хостов из группы Xfit</h1>
     {% if error %}
         <div style="color: red; font-weight: bold;">Ошибка: {{ error }}</div>
     {% endif %}
@@ -16,6 +16,8 @@
                 <div class="label">{{ host.name }}</div>
                 <div class="ip">IP: {{ host.ip }}</div>
                 <div class="channel">Канал: {{ host.channel }}</div>
+                <div class="loss">Loss 15m: {{ host.loss }}</div>
+                <div class="resp">Resp 1m: {{ host.resp }}</div>
             </div>
         {% endfor %}
     </div>


### PR DESCRIPTION
## Summary
- gather ICMP metrics and MikroTik channel for hosts in `Xfit`
- expose loss/response time gauges and channel metrics via Prometheus
- show loss and response data on the index page
- document the new metrics collection behavior

## Testing
- `python -m py_compile app/zabbix_api.py main.py app/mikrotik_api.py`

------
https://chatgpt.com/codex/tasks/task_e_688b23244f3c8325b5e515e46ca63d60

## Summary by Sourcery

Expose channel status and ICMP loss/response metrics for Xfit hosts via Prometheus and the web UI; centralize host retrieval logic and add IP lookup helper; update documentation accordingly.

New Features:
- Add Prometheus gauges for ICMP packet loss and 1m response time
- Expose ICMP loss and response time on the index page UI

Enhancements:
- Consolidate metrics collection to Xfit group and unify host data retrieval
- Introduce get_host_ip helper in Zabbix API for primary interface lookup

Documentation:
- Update AGENTS.md to document consolidated /metrics and /icmp_stats endpoints for Xfit hosts
- Modify HTML template header and fields to include ICMP loss and response time