### PR TITLE
Add special channel handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,9 @@ pages are rendered with Jinja2 templates under `templates/`.
 - The `/metrics` endpoint exposes channel status and ICMP statistics for
   hosts in the `xfit` group. Channel information is taken from hosts named
   `<name>.Gr3`.
+- If the MikroTik host is `ALT OF.Gr3` or `SEL.Gr3`, channel status is set to
+  `unknown` and ICMP metrics are collected from the Zabbix hosts `ALT OF` and
+  `SEL` respectively.
 - The `/icmp_stats` endpoint returns the same metrics as JSON for Grafana.
 
 ## Commit Messages

--- a/app/zabbix_api.py
+++ b/app/zabbix_api.py
@@ -195,3 +195,18 @@ def get_host_ip(host_name: str, auth: str) -> str:
         print(f"[ZBX] Host '{host_name}' not found")
         return ""
     return hosts[0].get("interfaces", [{}])[0].get("ip", "")
+
+
+def get_host_id(host_name: str, auth: str) -> str:
+    """Return Zabbix host ID for a given host name."""
+
+    params = {
+        "output": ["hostid"],
+        "filter": {"name": [host_name]},
+        "limit": 1,
+    }
+    hosts = zabbix_request("host.get", params, auth)
+    if not hosts:
+        print(f"[ZBX] Host '{host_name}' not found")
+        return ""
+    return hosts[0].get("hostid", "")

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ from prometheus_client import (
     CONTENT_TYPE_LATEST,
 )
 from app.mikrotik_api import get_channel_status, channel_status_value
-from app.zabbix_api import get_icmp_metrics
+from app.zabbix_api import get_icmp_metrics, get_host_id
 
 
 registry = CollectorRegistry()
@@ -55,8 +55,16 @@ def update_metrics():
         metrics = get_icmp_metrics(host["hostid"], auth)
 
         mikrotik_name = f"{name}.Gr3"
-        ip = get_host_ip(mikrotik_name, auth)
-        status = get_channel_status(ip, 8728)
+        if mikrotik_name in ("ALT OF.Gr3", "SEL.Gr3"):
+            special_name = "ALT OF" if mikrotik_name == "ALT OF.Gr3" else "SEL"
+            host_id = get_host_id(special_name, auth)
+            if host_id:
+                metrics = get_icmp_metrics(host_id, auth)
+            ip = get_host_ip(mikrotik_name, auth)
+            status = "unknown"
+        else:
+            ip = get_host_ip(mikrotik_name, auth)
+            status = get_channel_status(ip, 8728)
 
         channel_gauge.labels(host=name).set(channel_status_value(status))
         loss_gauge.labels(host=name).set(metrics.get("loss_15m", -1))
@@ -82,8 +90,16 @@ async def index(request: Request):
             metrics = get_icmp_metrics(h["hostid"], auth)
 
             mk_name = f"{name}.Gr3"
-            ip = get_host_ip(mk_name, auth)
-            channel = get_channel_status(ip, 8728)
+            if mk_name in ("ALT OF.Gr3", "SEL.Gr3"):
+                special_name = "ALT OF" if mk_name == "ALT OF.Gr3" else "SEL"
+                host_id = get_host_id(special_name, auth)
+                if host_id:
+                    metrics = get_icmp_metrics(host_id, auth)
+                ip = get_host_ip(mk_name, auth)
+                channel = "unknown"
+            else:
+                ip = get_host_ip(mk_name, auth)
+                channel = get_channel_status(ip, 8728)
             hosts.append({
                 "name": name,
                 "ip": ip,


### PR DESCRIPTION
## Summary
- return Zabbix host ID with `get_host_id`
- use ALT OF/SEL ICMP metrics when MikroTik host is `ALT OF.Gr3` or `SEL.Gr3`
- document special channel logic in `AGENTS.md`

## Testing
- `python -m py_compile app/zabbix_api.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_688c7c332818832592e1e01c7838331e