### PR TITLE
Collect ICMP response metrics for xfit_reserve

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,8 @@ pages are rendered with Jinja2 templates under `templates/`.
 - Configure `MIKROTIK_USER` and `MIKROTIK_PASSWORD` in the environment.
 - The `/metrics` endpoint exposes channel status and ICMP statistics for
   hosts in the `xfit` group. Channel information is taken from hosts named
-  `<name>.Gr3`.
+  `<name>.Gr3`. It also exports `ICMP response time avg 1m` for hosts in the
+  `xfit_reserve` group.
 - If the MikroTik host is `ALT OF.Gr3` or `SEL.Gr3`, ICMP metrics are read from
   the Zabbix hosts `ALT OF` and `SEL` respectively.  The channel is considered
   `main` when these hosts respond to ping and `unknown` otherwise.


### PR DESCRIPTION
## Summary
- Export ICMP response time metrics for hosts in the `xfit_reserve` group
- Document new `xfit_reserve` metrics in repository guidelines

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68906d1a4598832591c87bff399cedfe

## Summary by Sourcery

Extend the metrics collection pipeline to include hosts in the xfit_reserve group by gathering their ICMP response time metrics and update related documentation.

New Features:
- Collect and expose 1-minute ICMP response time metrics for hosts in the xfit_reserve group

Enhancements:
- Update update_metrics function to fetch and process xfit_reserve hosts

Documentation:
- Document the new xfit_reserve ICMP response metrics in AGENTS.md